### PR TITLE
Set default port 443 when protocol is https

### DIFF
--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# sugo-caller@5.0.3
+# sugo-caller@5.0.4
 
 Caller component of SUGOS.
 

--- a/lib/parsing/parse_caller_url.js
+++ b/lib/parsing/parse_caller_url.js
@@ -24,10 +24,11 @@ function parseCallerUrl (url) {
     }
     return url
   }
+  let protocol = url.protocol || get('location.protocol') || 'http:'
+  let defaultPort = protocol === 'https:' ? 443 : 80
   let {
-    protocol = get('location.protocol') || 'http',
     host = undefined,
-    port = get('location.port') || 80,
+    port = get('location.port') || defaultPort,
     hostname = get('location.hostname') || 'localhost',
     pathname = HubUrls.CALLER_URL
   } = url


### PR DESCRIPTION
 https にした時のデフォルトのポート番号を443にした。`window.location.port` は https の時には空文字 `''` になるため、これまでは SugoCaller に port オプションを渡さずに https でアクセスすると、 port = 80 と解釈されて接続できなかった。